### PR TITLE
[token] Fixes incorrect authorization type.

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
     "sinon": "^1.17.7"
   },
   "dependencies": {
+    "@ambassify/fetch": "^1.0.1",
     "jsonwebtoken": "^7.3.0",
     "lodash": "^4.17.4",
-    "mitt": "^1.0.1",
-    "node-fetch": "^1.6.3"
+    "mitt": "^1.0.1"
   }
 }

--- a/src/client.js
+++ b/src/client.js
@@ -1,5 +1,5 @@
 const _pick = require('lodash/pick');
-const fetch = require('node-fetch');
+const fetch = require('@ambassify/fetch');
 const mitt = require('mitt'); // 200kb event emitter
 const URL = require('url');
 
@@ -85,8 +85,12 @@ EventBusClient.prototype = {
             }
         };
 
-        if (data.accessToken)
-            opts.headers['Authorization'] = `BuboBox ${data.accessToken}`;
+        if (data.accessToken) {
+            opts.headers['Authorization'] = `Bearer ${data.accessToken}`;
+
+            // Legacy tokens
+            opts.headers['X-API-KEY'] = data.accessToken;
+        }
 
         fetch(url, opts)
             .then(res => {

--- a/src/public-key.js
+++ b/src/public-key.js
@@ -1,5 +1,5 @@
 const URL = require('url');
-const fetch = require('node-fetch');
+const fetch = require('@ambassify/fetch');
 
 const CACHE = {};
 const MAX_AGE = 300 * 1000;

--- a/test/client.js
+++ b/test/client.js
@@ -83,7 +83,10 @@ describe('#eventbus', function() {
 
     it('Should append header passed through options', function() {
         const request = nock('http://fake-eventbus.ambassify.eu', {
-                reqheaders: { 'authorization': 'BuboBox 2222' }
+                reqheaders: {
+                    'authorization': 'Bearer 2222',
+                    'x-api-key': '2222'
+                }
             })
             .post('/eventbus/event/event_created', {
                 payload: { 'hello': 'world' }


### PR DESCRIPTION
Default to `Bearer` now instead of `BuboBox` and add `X-API-KEY` for
legacy tokens.